### PR TITLE
Support query part in service method

### DIFF
--- a/helium/src/main/groovy/com/stanfy/helium/handler/codegen/tests/RestApiPokeTestsGenerator.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/handler/codegen/tests/RestApiPokeTestsGenerator.groovy
@@ -98,7 +98,9 @@ class RestApiPokeTestsGenerator extends BaseUnitTestsGenerator {
         requestUriReady |= pathExamplesPresent
       }
 
-      parametrizedUri = "${parametrizedUri}$uriQueryExample"
+      if (uriQueryExample) {
+        parametrizedUri = "${parametrizedUri}${method.hasQueryInPath() ? '&' : '?'}${uriQueryExample}"
+      }
 
       if (requestUriReady && !method.hasBody()) {
         // can make an example

--- a/helium/src/main/groovy/com/stanfy/helium/handler/tests/HttpExecutor.java
+++ b/helium/src/main/groovy/com/stanfy/helium/handler/tests/HttpExecutor.java
@@ -74,11 +74,12 @@ public class HttpExecutor implements MethodsExecutor {
         throw new AssertionError(e);
       }
       query = queryWriter.toString();
-      if (query.length() > 0) {
-        query = "?" + query;
-      }
     }
-    return requestPath + query;
+    String res = requestPath;
+    if (query.length() > 0) {
+      res += (method.hasQueryInPath() ? "&" : "?") + query;
+    }
+    return res;
   }
 
   @Override

--- a/helium/src/test/groovy/com/stanfy/helium/model/ServiceMethodSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/model/ServiceMethodSpec.groovy
@@ -74,7 +74,7 @@ class ServiceMethodSpec extends Specification {
     String q3 = method.getUriQueryWithExamples('UTF-8')
 
     expect:
-    q1 == '?a=1&b=2'
+    q1 == 'a=1&b=2'
     q2 == ''
     q3 == ''
 
@@ -122,12 +122,13 @@ class ServiceMethodSpec extends Specification {
 
   def "supports normal templating"() {
     given:
-    method.path = '/p/{a}/{b}{c}'
+    method.path = '/p/{a}/{b}{c}?test=value'
 
     expect:
     method.hasRequiredParametersInPath()
+    method.hasQueryInPath()
     method.pathParameters == ['a', 'b', 'c']
-    method.getPathWithParameters(a: '1', b: '2', c:'3') == '/p/1/23'
+    method.getPathWithParameters(a: '1', b: '2', c:'3') == '/p/1/23?test=value'
   }
 
   def "normalized path"() {
@@ -136,6 +137,19 @@ class ServiceMethodSpec extends Specification {
 
     expect:
     method.normalizedPath == '/{name}/{param}'
+  }
+
+  def "uri query"() {
+    given:
+    method.parameters = new Message(name: 'some_type')
+    method.parameters.addField(new Field(name: 'param1', type: new Type(name: 'string')))
+    method.parameters.addField(new Field(name: 'param2', type: new Type(name: 'string')))
+
+    and:
+    def uriQuery = method.getUriQueryWithParameters('UTF-8', ['param1': 'value1', 'param2': 'value2', 'other': 'value'])
+
+    expect:
+    uriQuery == 'param1=value1&param2=value2'
   }
 
 }

--- a/samples/httpbin/httpbin.api
+++ b/samples/httpbin/httpbin.api
@@ -1,6 +1,9 @@
 note 'Httpbin service - simply returns all data you sent back to you.'
 
+type 'ParamsDictionary' dictionary('string', 'string')
+
 type 'BaseHttpBinResponse' message(skipUnknownFields: true) {
+  args   'ParamsDictionary'
   data   'string'
   origin 'string'
   url    'string'
@@ -27,11 +30,9 @@ service {
     body form('Person')
   }
 
-
-  tests {
-
-    scenario 'Send Peter' spec {
-      def peterResp = post '/post' with {
+  describe 'Send Peter' spec {
+    it('should pass') {
+      def peterResp = service.post '/post' with {
         body form {
           name 'Peter Heel'
           age  '5'
@@ -59,12 +60,11 @@ service {
     body data()
   }
 
-  tests {
-
-    scenario 'Send dragon bytes' spec {
+  describe 'Send dragon bytes' spec {
+    it('should pass') {
       def dragonBytes = "Dragon".getBytes()
 
-      def res = post "/post" with {
+      def res = service.post "/post" with {
         body bytes(dragonBytes)
       }
 
@@ -73,7 +73,6 @@ service {
       assert res.body?.data.getBytes() == dragonBytes
     }
   }
-
 }
 
 // Text and file upload service.
@@ -100,6 +99,9 @@ service {
       text 'string'
       file file()
     }
+    parameters {
+      param 'string'
+    }
   }
 
   describe "upload pig" spec {
@@ -109,6 +111,9 @@ service {
     String pigName = 'This is a pig.'
 
     def res = service.post "/post" with {
+      parameters {
+        param 'value'
+      }
       body multipart {
         file f
         text pigName
@@ -118,6 +123,34 @@ service {
     it("must succeed") { res.mustSucceed() }
     it("submits text") { res.body?.form?.text.contains("This is a pig.") }
     it("submits file") { res.body?.files?.file?.contains(f.bytes.encodeBase64().toString()) }
+    it("submits parameters") { res.body?.args?.param == 'value' }
+  }
+
+}
+
+service {
+  // TODO: Think how we can get an alternative.
+  name "ParamsInPathService"
+  location "http://httpbin.org"
+
+  post '/post?name1=value1' spec {
+    response 'BaseHttpBinResponse'
+    parameters {
+      name2 'string'
+    }
+  }
+
+  describe "testing" spec {
+    it('should pass') {
+      def resp = service.post '/post?name1=value1' with {
+        parameters {
+          name2 'value2'
+        }
+      }
+      resp.mustSucceed()
+      assert resp.body?.args?.name1 == 'value1'
+      assert resp.body?.args?.name2 == 'value2'
+    }
   }
 
 }


### PR DESCRIPTION
Supports writing something like
```
get '/some/path?include=something_else'
```
Ideally the syntax should allow this via `parameters`, but it needs some revision of DSL.

Closes #1.