### PR TITLE
Fix include of the same file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: android
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ android:
   components:
     - build-tools-23.0.1
     - android-23
+    - android-21
 
 env:
   global:

--- a/helium/src/main/groovy/com/stanfy/helium/internal/dsl/ProjectDsl.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/internal/dsl/ProjectDsl.groovy
@@ -213,8 +213,8 @@ class ProjectDsl implements Project, BehaviorDescriptionContainer {
     structure.add note
   }
 
-  public void include(final Object spec) {
-    final File specFile
+  void include(final Object spec) {
+    File specFile
     if (spec instanceof File) {
       specFile = spec as File
     } else {
@@ -225,6 +225,7 @@ class ProjectDsl implements Project, BehaviorDescriptionContainer {
         specFile = new File(path)
       }
     }
+    specFile = specFile.canonicalFile
     if (!includedFiles.contains(specFile)) {
       includedFiles.add specFile
       ScriptExtender.fromFile(specFile, charset).withVars(variablesBinding).handle(this)

--- a/samples/includes/README.md
+++ b/samples/includes/README.md
@@ -1,0 +1,1 @@
+Illustrates how specs can be included to each other.

--- a/samples/includes/build.gradle
+++ b/samples/includes/build.gradle
@@ -1,0 +1,25 @@
+buildscript {
+  repositories {
+    mavenLocal()
+    mavenCentral()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+  }
+  dependencies {
+    classpath 'com.stanfy.helium:gradle-plugin:0.8.3-SNAPSHOT'
+  }
+}
+
+apply plugin: 'helium'
+
+helium {
+  specification file('service_a/service_a.api')
+  specification file('service_b/service_b.api')
+}
+
+task clean(type: Delete) {
+  delete buildDir
+}
+
+task check() {
+  dependsOn 'genApiTestsServiceA', 'genApiTestsServiceB'
+}

--- a/samples/includes/common.api
+++ b/samples/includes/common.api
@@ -1,0 +1,5 @@
+note 'Common types'
+
+type 'custom_type' spec {
+  description 'Common custom type'
+}

--- a/samples/includes/service_a/service_a.api
+++ b/samples/includes/service_a/service_a.api
@@ -1,0 +1,13 @@
+include "$baseDir/../common.api"
+
+note 'Service A'
+
+service {
+  name 'A'
+  location 'http://localhost:8080'
+
+  get '/test_1' spec {
+    response 'custom_type'
+  }
+
+}

--- a/samples/includes/service_b/service_b.api
+++ b/samples/includes/service_b/service_b.api
@@ -1,0 +1,25 @@
+include "$baseDir/../common.api"
+include "$baseDir/../service_a/service_a.api"
+
+note 'Service B'
+
+service {
+  name 'B'
+  location 'http://localhost:8080'
+
+  get '/test_2' spec {
+    response 'custom_type'
+  }
+
+}
+
+describe 'Integration' spec {
+  def serviceA = service_b('A')
+  def serviceB = service_b('B')
+
+  it('works') {
+    serviceA.get '/test_1' with { }
+    serviceB.get '/test_2' with { }
+  }
+
+}


### PR DESCRIPTION
When the same spec is included using different relative paths, we were not able
to understand it's already included.

Fixes #17.

fyi @Vandalko 
I'll appreciate if your remove the workarounds now.