### PR TITLE
Limit Swagger spec content

### DIFF
--- a/codegen/swagger/src/main/java/com/stanfy/helium/swagger/SwaggerHandler.java
+++ b/codegen/swagger/src/main/java/com/stanfy/helium/swagger/SwaggerHandler.java
@@ -44,14 +44,23 @@ public class SwaggerHandler implements Handler {
   private static final String DEF_PREFIX = "#/definitions/";
 
   private final File destination;
+  private final SwaggerOptions options;
 
   private final SchemaBuilder schemaBuilder = new SchemaBuilder(DEF_PREFIX);
 
   public SwaggerHandler(File destination) {
+    this(destination, new SwaggerOptions());
+  }
+
+  public SwaggerHandler(File destination, SwaggerOptions options) {
     if (destination.exists() && !destination.isDirectory()) {
       throw new IllegalArgumentException("Destination must be a folder");
     }
+    if (options == null) {
+      throw new IllegalArgumentException("Options cannot be null");
+    }
     this.destination = destination;
+    this.options = options;
   }
 
   @Override
@@ -104,6 +113,10 @@ public class SwaggerHandler implements Handler {
       if (!service.getMethods().isEmpty()) {
         LinkedHashMap<String, Path> paths = new LinkedHashMap<>(service.getMethods().size());
         for (ServiceMethod m : service.getMethods()) {
+          if (!options.checkIncludes(m)) {
+            continue;
+          }
+
           Path.Method method = swaggerPath(paths, m).swaggerMethod(m);
           method.summary = m.getName();
           method.description = m.getDescription();

--- a/codegen/swagger/src/main/java/com/stanfy/helium/swagger/SwaggerOptions.java
+++ b/codegen/swagger/src/main/java/com/stanfy/helium/swagger/SwaggerOptions.java
@@ -1,0 +1,58 @@
+package com.stanfy.helium.swagger;
+
+import com.stanfy.helium.model.ServiceMethod;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/** Options for SwaggerHandler. */
+public class SwaggerOptions {
+
+  /** What endpoints into Swagger spec. */
+  private List<Pattern> includes = Collections.emptyList();
+
+  private static void checkNotNull(Object arg) {
+    if (arg == null) {
+      throw new IllegalArgumentException("Argument cannot be null");
+    }
+  }
+
+  public void includePatterns(List<Pattern> includes) {
+    checkNotNull(includes);
+    this.includes = includes;
+  }
+
+  public void includes(List<String> includes) {
+    checkNotNull(includes);
+    this.includes = new ArrayList<>(includes.size());
+    for (String arg : includes) {
+      this.includes.add(Pattern.compile(arg));
+    }
+  }
+
+  public void includes(String... includes) {
+    includes(Arrays.asList(includes));
+  }
+
+  public List<Pattern> getIncludes() {
+    return includes;
+  }
+
+  boolean checkIncludes(ServiceMethod m) {
+    if (includes.isEmpty()) {
+      return true;
+    }
+
+    String name = m.getType().name() + " " + m.getPath();
+    for (Pattern p : includes) {
+      if (p.matcher(name).matches()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/codegen/swagger/src/test/groovy/com/stanfy/helium/swagger/SwaggerHandlerSpec.groovy
+++ b/codegen/swagger/src/test/groovy/com/stanfy/helium/swagger/SwaggerHandlerSpec.groovy
@@ -261,7 +261,7 @@ class SwaggerHandlerSpec extends Specification {
   def "multipart body"() {
     given:
     handler.handle(project)
-    def data =specData(testSpec())
+    def data = specData(testSpec())
 
     expect:
     data.paths?.'/multipart'?.post != null
@@ -272,6 +272,19 @@ class SwaggerHandlerSpec extends Specification {
     data.paths.'/multipart'.post.parameters[0].required
     data.paths.'/multipart'.post.parameters[0].type == 'file'
     data.paths.'/multipart'.post.consumes == ['multipart/form-data']
+  }
+
+  def "respect includes in options"() {
+    given:
+    def options = new SwaggerOptions()
+    options.includes('GET /products')
+    handler = new SwaggerHandler(dir, options)
+    handler.handle(project)
+    def data = specData(uberSpec())
+
+    expect:
+    data.paths?.keySet() == ['/products'] as Set
+    data.paths.'/products'.keySet() == ['get'] as Set
   }
 
   void cleanup() {

--- a/codegen/swagger/src/test/groovy/com/stanfy/helium/swagger/SwaggerOptionsSpec.groovy
+++ b/codegen/swagger/src/test/groovy/com/stanfy/helium/swagger/SwaggerOptionsSpec.groovy
@@ -1,0 +1,68 @@
+package com.stanfy.helium.swagger
+
+import com.stanfy.helium.model.MethodType
+import com.stanfy.helium.model.ServiceMethod
+import spock.lang.Specification
+
+import java.util.regex.Pattern
+
+/** Spec for SwaggerOptions. */
+class SwaggerOptionsSpec extends Specification {
+
+  private SwaggerOptions options
+
+  def setup() {
+    options = new SwaggerOptions()
+  }
+
+  def "use strings for patterns"() {
+    when:
+    options.includes '.*/some/path/.+', '/'
+
+    then:
+    options.includes.size() == 2
+  }
+
+  def "use string list for patterns"() {
+    when:
+    options.includes(['.*/some/path/.+', '/'])
+
+    then:
+    options.includes.size() == 2
+  }
+
+  def "use patterns"() {
+    when:
+    options.includePatterns([Pattern.compile('.*/some/path/.+')])
+
+    then:
+    options.includes.size() == 1
+  }
+
+  def "check includes"() {
+    given:
+    ServiceMethod m1 = new ServiceMethod(type: MethodType.DELETE, path: '/path/one')
+    ServiceMethod m2 = new ServiceMethod(type: MethodType.POST, path: '/path/two')
+    ServiceMethod m3 = new ServiceMethod(type: MethodType.GET, path: '/path/three')
+
+    when:
+    options.includes 'DELETE /path/.+', '.+/two.*'
+
+    then:
+    options.checkIncludes(m1)
+    options.checkIncludes(m2)
+    !options.checkIncludes(m3)
+  }
+
+  def "empty includes"() {
+    given:
+    ServiceMethod m1 = new ServiceMethod(type: MethodType.DELETE, path: '/path/one')
+    ServiceMethod m2 = new ServiceMethod(type: MethodType.POST, path: '/path/two')
+    ServiceMethod m3 = new ServiceMethod(type: MethodType.GET, path: '/path/three')
+
+    expect:
+    options.checkIncludes(m1)
+    options.checkIncludes(m2)
+    options.checkIncludes(m3)
+  }
+}

--- a/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/tasks/SwaggerTask.groovy
+++ b/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/tasks/SwaggerTask.groovy
@@ -1,13 +1,26 @@
 package com.stanfy.helium.gradle.tasks
 
 import com.stanfy.helium.swagger.SwaggerHandler
+import com.stanfy.helium.swagger.SwaggerOptions
+import org.gradle.api.tasks.Input
 
 /** Task for generating Swagger spec. */
-class SwaggerTask extends BaseHeliumTask<Object> {
+class SwaggerTask extends BaseHeliumTask<SwaggerOptions> {
+
+  private List<String> includes
+
+  @Input
+  void includes(String... includes) {
+    this.includes = Arrays.asList(includes)
+  }
 
   @Override
   protected void doIt() {
-    helium.processBy(new SwaggerHandler(output))
+    options = new SwaggerOptions()
+    if (this.includes) {
+      options.includes(this.includes)
+    }
+    helium.processBy(new SwaggerHandler(output, options))
   }
 
 }

--- a/samples/swagger/build.gradle
+++ b/samples/swagger/build.gradle
@@ -22,12 +22,17 @@ task clean(type: Delete) {
 }
 
 afterEvaluate {
+  generateSwaggerSpec {
+    includes 'GET /products'
+  }
+
   task check(dependsOn: 'generateSwaggerSpec')
   check << {
     def file = new File(generateSwaggerSpec.output, 'Uber_API.json')
     assert file
     def json = new JsonSlurper().parse(file)
     assert json.info.title == 'Uber API'
+    assert json.paths.'/products'.keySet() == ['get'] as Set
   }
 
 }

--- a/samples/swagger/uber.api
+++ b/samples/swagger/uber.api
@@ -36,4 +36,11 @@ service {
     }
     response 'ProductList'
   }
+
+  post '/products' spec {
+    name 'Does not exist'
+    description 'Ignored during Swagger spec generation'
+    body 'Product'
+    response 'Product'
+  }
 }


### PR DESCRIPTION
When Swagger generation is configured, we can configure what endpoints are included
to prevent private APIs publication.