### PR TITLE
Add generic object converter

### DIFF
--- a/helium/src/main/groovy/com/stanfy/helium/format/json/ClosureJsonConverter.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/format/json/ClosureJsonConverter.groovy
@@ -30,6 +30,10 @@ class ClosureJsonConverter implements PrimitiveReader<JsonReader>, PrimitiveWrit
     }
   }
 
+  public static final Closure<?> AS_GENERIC_READER = { JsonReader reader ->
+    return JsonToGeneric.readValue(reader)
+  }
+
   /** Writer closure. */
   final Closure<?> writer
   /** Reader closure. */

--- a/helium/src/main/groovy/com/stanfy/helium/format/json/JsonToGeneric.java
+++ b/helium/src/main/groovy/com/stanfy/helium/format/json/JsonToGeneric.java
@@ -1,0 +1,64 @@
+package com.stanfy.helium.format.json;
+
+import com.google.gson.stream.JsonReader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class JsonToGeneric {
+
+  private JsonToGeneric() { /* hidden */ }
+
+  static Map<String, ?> readMap(JsonReader reader) throws IOException {
+    LinkedHashMap<String, Object> result = new LinkedHashMap<>();
+    reader.beginObject();
+    while (reader.hasNext()) {
+      String name = reader.nextName();
+      result.put(name, readValue(reader));
+    }
+    reader.endObject();
+    return result;
+  }
+
+  static List<?> readList(JsonReader reader) throws IOException {
+    ArrayList<Object> result = new ArrayList<>();
+    reader.beginArray();
+    while (reader.hasNext()) {
+      result.add(readValue(reader));
+    }
+    reader.endArray();
+    return result;
+  }
+
+  static Object readValue(JsonReader reader) throws IOException {
+    Object value = null;
+    switch (reader.peek()) {
+      case BEGIN_OBJECT:
+        value = readMap(reader);
+        break;
+      case BEGIN_ARRAY:
+        value = readList(reader);
+        break;
+      case NUMBER:
+        value = reader.nextDouble();
+        break;
+      case STRING:
+        value = reader.nextString();
+        break;
+      case BOOLEAN:
+        value = reader.nextBoolean();
+        break;
+      case NULL:
+        reader.nextNull();
+        break;
+      default:
+        reader.skipValue();
+    }
+    return value;
+  }
+
+
+}

--- a/helium/src/main/groovy/com/stanfy/helium/internal/dsl/ConfigurableType.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/internal/dsl/ConfigurableType.groovy
@@ -47,11 +47,11 @@ class ConfigurableType extends ConfigurableProxy<Type> {
     return this.@constraints
   }
 
-  public class From {
-    public Closure<?> asString() {
+  class From {
+    Closure<?> asString() {
       return ClosureJsonConverter.AS_STRING_READER
     }
-    public Closure<?> asDate(final String dateFormat) {
+    Closure<?> asDate(final String dateFormat) {
       return stringParser("Expected format: $dateFormat") { String str ->
         return DateTimeFormat.forPattern(dateFormat)
             .withLocale(Locale.US)
@@ -59,7 +59,10 @@ class ConfigurableType extends ConfigurableProxy<Type> {
             .toDate()
       }
     }
-    public Closure<?> parseString(Closure<?> parser) {
+    Closure<?> asGeneric() {
+      return ClosureJsonConverter.AS_GENERIC_READER
+    }
+    Closure<?> parseString(Closure<?> parser) {
       return stringParser(null, parser)
     }
 

--- a/helium/src/test/groovy/com/stanfy/helium/format/json/JsonToGenericSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/format/json/JsonToGenericSpec.groovy
@@ -1,0 +1,67 @@
+package com.stanfy.helium.format.json
+
+import com.google.gson.stream.JsonReader
+import okio.Buffer
+import spock.lang.Specification
+
+/** Generic transformations for JSON input. */
+class JsonToGenericSpec extends Specification {
+
+  Buffer inputBuffer
+  JsonReader jsonReader
+
+  def setup() {
+    inputBuffer = new Buffer()
+    jsonReader = new JsonReader(new InputStreamReader(inputBuffer.inputStream(), "UTF-8"))
+    jsonReader.lenient = true
+  }
+
+  def "read numbers"() {
+    when:
+    inputBuffer.writeUtf8("123")
+    then:
+    JsonToGeneric.readValue(jsonReader) == 123
+  }
+
+  def "read real numbers"() {
+    when:
+    inputBuffer.writeUtf8("123.5")
+    then:
+    JsonToGeneric.readValue(jsonReader) == 123.5
+  }
+
+  def "read strings"() {
+    when:
+    inputBuffer.writeUtf8("\"abc\"")
+    then:
+    JsonToGeneric.readValue(jsonReader) == "abc"
+  }
+
+  def "read boolean"() {
+    when:
+    inputBuffer.writeUtf8("false")
+    then:
+    JsonToGeneric.readValue(jsonReader) == false
+  }
+
+  def "read null"() {
+    when:
+    inputBuffer.writeUtf8("null")
+    then:
+    JsonToGeneric.readValue(jsonReader) == null
+  }
+
+  def "read object"() {
+    when:
+    inputBuffer.writeUtf8("{\"a\": \"b\", \"c\": 123}")
+    then:
+    JsonToGeneric.readValue(jsonReader) == ['a': 'b', 'c': 123]
+  }
+
+  def "read array"() {
+    when:
+    inputBuffer.writeUtf8("[\"1\", 2, true]")
+    then:
+    JsonToGeneric.readValue(jsonReader) == ['1', 2, true]
+  }
+}

--- a/helium/src/test/groovy/com/stanfy/helium/internal/dsl/ProjectDslSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/internal/dsl/ProjectDslSpec.groovy
@@ -476,6 +476,20 @@ class ProjectDslSpec extends Specification {
     writer != null
   }
 
+  def "can describe generic reader"() {
+    given:
+    dsl.type "custom" spec {
+      description "Custom type"
+      from("json") { asGeneric() }
+    }
+    def customType = dsl.types.byName("custom")
+    def reader = dsl.types.customReaders(MediaType.parse('*/json'))[customType]
+
+    expect:
+    customType != null
+    reader != null
+  }
+
   def "should allow empty response type"() {
     when:
     dsl.service {


### PR DESCRIPTION
This allows to specify some type as a generic entity and convert it to a dict/array
during the test.

Example:
```
type 'Generic' spec {
  description 'Some generic entity'
  from('json') { asGeneric() }
}
```