### PR TITLE
Extend Swagger options to exclude message fields

### DIFF
--- a/codegen/json/json-schema/src/main/groovy/com/stanfy/helium/handler/codegen/json/schema/JsonSchemaGenerator.groovy
+++ b/codegen/json/json-schema/src/main/groovy/com/stanfy/helium/handler/codegen/json/schema/JsonSchemaGenerator.groovy
@@ -44,29 +44,29 @@ class JsonSchemaGenerator extends BaseGenerator<JsonSchemaGeneratorOptions> impl
   }
 
   @Override
-  public void handle(Project project) {
-    JsonSchemaGeneratorOptions options = getOptions();
+  void handle(Project project) {
+    JsonSchemaGeneratorOptions options = getOptions()
 
     for (Type type : project.getTypes().all()) {
       boolean shouldProcess = options.isTypeUserDefinedMessage(type) && options.isTypeIncluded(type);
       if (shouldProcess) {
         final File schemaFile = new File(schemeOutputDir, type.getCanonicalName().concat(JSON_SCHEME_SUFFIX)
-            .concat(EXT_JSON));
-        FileWriter fileWriter = null;
+            .concat(EXT_JSON))
+        FileWriter fileWriter = null
         try {
-          fileWriter = new FileWriter(schemaFile);
-          write((Message) type, fileWriter);
+          fileWriter = new FileWriter(schemaFile)
+          write((Message) type, fileWriter)
         } catch (IOException e) {
-          throw new RuntimeException(e);
+          throw new RuntimeException(e)
         } finally {
-          IOUtils.closeQuietly(fileWriter);
+          IOUtils.closeQuietly(fileWriter)
         }
       }
     }
   }
 
   void write(Message msg, Appendable writer) {
-    def schema = builder.makeSchemaFromMessage(msg)
+    def schema = builder.makeSchemaFromMessage(msg, SchemaBuilder.FULL_SELECTION)
     schema.schema = JSON_SCHEMA_DRAFT_4_URI
 
     gson.toJson(schema, writer)

--- a/codegen/json/json-schema/src/test/groovy/com/stanfy/helium/handler/codegen/json/schema/SchemaBuilderSpec.groovy
+++ b/codegen/json/json-schema/src/test/groovy/com/stanfy/helium/handler/codegen/json/schema/SchemaBuilderSpec.groovy
@@ -1,6 +1,7 @@
 package com.stanfy.helium.handler.codegen.json.schema
 
 import com.stanfy.helium.DefaultType
+import com.stanfy.helium.internal.utils.SelectionRules
 import com.stanfy.helium.model.Dictionary
 import com.stanfy.helium.model.Field
 import com.stanfy.helium.model.Message
@@ -71,4 +72,21 @@ class SchemaBuilderSpec extends Specification {
     builder.makeSchemaFromType(msg).@properties.ff?.type == null
   }
 
+  def "use selection to filter fields"() {
+    given:
+    def msg = new Message(name: "ComplexType")
+    msg.addField(new Field(name: 'foo', type: new Type(name: 'string')))
+    msg.addField(new Field(name: 'bar', type: new Type(name: 'string')))
+    def msgSelection = new SelectionRules(msg.name)
+    msgSelection.excludes('foo')
+    def selection = new SelectionRules("test")
+    selection.nest(msgSelection)
+
+    when:
+    def schema = builder.makeSchemaFromType(msg, selection)
+
+    then:
+    schema.@properties.keySet() == ['bar'] as Set
+    schema.required == ['bar']
+  }
 }

--- a/codegen/swagger/src/main/java/com/stanfy/helium/swagger/SwaggerOptions.java
+++ b/codegen/swagger/src/main/java/com/stanfy/helium/swagger/SwaggerOptions.java
@@ -1,58 +1,40 @@
 package com.stanfy.helium.swagger;
 
+import com.stanfy.helium.internal.utils.SelectionRules;
+import com.stanfy.helium.model.Field;
+import com.stanfy.helium.model.Message;
 import com.stanfy.helium.model.ServiceMethod;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.regex.Pattern;
+import com.stanfy.helium.model.Type;
 
 /** Options for SwaggerHandler. */
 public class SwaggerOptions {
 
-  /** What endpoints into Swagger spec. */
-  private List<Pattern> includes = Collections.emptyList();
+  /** Endpoint rules. */
+  private final SelectionRules endpoints = new SelectionRules("endpoints");
 
-  private static void checkNotNull(Object arg) {
-    if (arg == null) {
-      throw new IllegalArgumentException("Argument cannot be null");
-    }
+  /** Type rules. */
+  private final SelectionRules types = new SelectionRules("types");
+
+  public SelectionRules getEndpoints() {
+    return endpoints;
   }
 
-  public void includePatterns(List<Pattern> includes) {
-    checkNotNull(includes);
-    this.includes = includes;
-  }
-
-  public void includes(List<String> includes) {
-    checkNotNull(includes);
-    this.includes = new ArrayList<>(includes.size());
-    for (String arg : includes) {
-      this.includes.add(Pattern.compile(arg));
-    }
-  }
-
-  public void includes(String... includes) {
-    includes(Arrays.asList(includes));
-  }
-
-  public List<Pattern> getIncludes() {
-    return includes;
+  public SelectionRules getTypes() {
+    return types;
   }
 
   boolean checkIncludes(ServiceMethod m) {
-    if (includes.isEmpty()) {
-      return true;
-    }
-
     String name = m.getType().name() + " " + m.getPath();
-    for (Pattern p : includes) {
-      if (p.matcher(name).matches()) {
-        return true;
-      }
-    }
-    return false;
+    return endpoints.check(name);
+  }
+
+  boolean checkIncludes(Type type) {
+    return types.check(type.getName());
+  }
+
+  boolean checkIncludes(Message message, Field field) {
+    SelectionRules nested = types.nested(message.getName());
+    return nested == null || nested.check(field.getName());
   }
 
 }

--- a/codegen/swagger/src/test/groovy/com/stanfy/helium/swagger/SwaggerOptionsSpec.groovy
+++ b/codegen/swagger/src/test/groovy/com/stanfy/helium/swagger/SwaggerOptionsSpec.groovy
@@ -1,10 +1,12 @@
 package com.stanfy.helium.swagger
 
+import com.stanfy.helium.internal.utils.SelectionRules
+import com.stanfy.helium.model.Field
+import com.stanfy.helium.model.Message
 import com.stanfy.helium.model.MethodType
 import com.stanfy.helium.model.ServiceMethod
+import com.stanfy.helium.model.Type
 import spock.lang.Specification
-
-import java.util.regex.Pattern
 
 /** Spec for SwaggerOptions. */
 class SwaggerOptionsSpec extends Specification {
@@ -15,38 +17,15 @@ class SwaggerOptionsSpec extends Specification {
     options = new SwaggerOptions()
   }
 
-  def "use strings for patterns"() {
-    when:
-    options.includes '.*/some/path/.+', '/'
 
-    then:
-    options.includes.size() == 2
-  }
-
-  def "use string list for patterns"() {
-    when:
-    options.includes(['.*/some/path/.+', '/'])
-
-    then:
-    options.includes.size() == 2
-  }
-
-  def "use patterns"() {
-    when:
-    options.includePatterns([Pattern.compile('.*/some/path/.+')])
-
-    then:
-    options.includes.size() == 1
-  }
-
-  def "check includes"() {
+  def "check endpoints"() {
     given:
     ServiceMethod m1 = new ServiceMethod(type: MethodType.DELETE, path: '/path/one')
     ServiceMethod m2 = new ServiceMethod(type: MethodType.POST, path: '/path/two')
     ServiceMethod m3 = new ServiceMethod(type: MethodType.GET, path: '/path/three')
 
     when:
-    options.includes 'DELETE /path/.+', '.+/two.*'
+    options.endpoints.includes 'DELETE /path/.+', '.+/two.*'
 
     then:
     options.checkIncludes(m1)
@@ -65,4 +44,36 @@ class SwaggerOptionsSpec extends Specification {
     options.checkIncludes(m2)
     options.checkIncludes(m3)
   }
+
+  def "check types"() {
+    given:
+    options.types.includes('TestMessage')
+
+    expect:
+    options.checkIncludes(new Type(name: 'TestMessage'))
+    !options.checkIncludes(new Type(name: 'AnotherName'))
+  }
+
+  def "check field names"() {
+    given:
+    Message msg = new Message(name: 'TestMessage')
+    msg.addField(new Field(name: 'foo', type: new Type(name: 'string')))
+    msg.addField(new Field(name: 'bar', type: new Type(name: 'string')))
+    Message msg2 = new Message(name: 'TestMessage2')
+    msg2.addField(new Field(name: 'foo', type: new Type(name: 'string')))
+    msg2.addField(new Field(name: 'bar', type: new Type(name: 'string')))
+
+    and:
+    options.types.excludes('Something')
+    def msgRules = new SelectionRules('TestMessage')
+    msgRules.includes('\\w+')
+    msgRules.excludes('bar')
+    options.types.nest(msgRules)
+
+    expect:
+    options.checkIncludes(msg, msg.fields[0])
+    !options.checkIncludes(msg, msg.fields[1])
+    options.checkIncludes(msg2, msg2.fields[0])
+  }
+
 }

--- a/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/internal/SelectionRulesBuilder.groovy
+++ b/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/internal/SelectionRulesBuilder.groovy
@@ -1,0 +1,27 @@
+package com.stanfy.helium.gradle.internal
+
+import com.stanfy.helium.internal.utils.DslUtils
+import com.stanfy.helium.internal.utils.SelectionRules
+
+class SelectionRulesBuilder {
+
+  final SelectionRules rules
+
+  SelectionRulesBuilder(SelectionRules rules) {
+    this.rules = rules
+  }
+
+  @Override
+  def invokeMethod(String name, Object args) {
+    if (name in ['excludes', 'includes']) {
+      rules.invokeMethod(name, args)
+      return
+    }
+
+    Closure<?> config = (args as Object[])[0] as Closure<?>
+    SelectionRules nested = new SelectionRules(name)
+    DslUtils.runWithProxy(nested, config)
+    rules.nest(nested)
+  }
+
+}

--- a/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/tasks/SwaggerTask.groovy
+++ b/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/tasks/SwaggerTask.groovy
@@ -1,26 +1,29 @@
 package com.stanfy.helium.gradle.tasks
 
+import com.stanfy.helium.gradle.internal.SelectionRulesBuilder
+import com.stanfy.helium.internal.utils.DslUtils
 import com.stanfy.helium.swagger.SwaggerHandler
 import com.stanfy.helium.swagger.SwaggerOptions
-import org.gradle.api.tasks.Input
 
 /** Task for generating Swagger spec. */
 class SwaggerTask extends BaseHeliumTask<SwaggerOptions> {
 
-  private List<String> includes
+  {
+    options = new SwaggerOptions()
+  }
 
-  @Input
-  void includes(String... includes) {
-    this.includes = Arrays.asList(includes)
+  void endpoints(Closure<?> config) {
+    DslUtils.runWithProxy(options.endpoints, config)
+  }
+
+  void types(Closure<?> config) {
+    DslUtils.runWithProxy(new SelectionRulesBuilder(options.types), config)
   }
 
   @Override
   protected void doIt() {
-    options = new SwaggerOptions()
-    if (this.includes) {
-      options.includes(this.includes)
-    }
     helium.processBy(new SwaggerHandler(output, options))
   }
+
 
 }

--- a/helium/src/main/groovy/com/stanfy/helium/model/Message.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/model/Message.groovy
@@ -11,7 +11,7 @@ final class Message extends Type {
   /** Flag that allows to skip (ignore) all unknown fields met in response during validation in generated tests. */
   boolean skipUnknownFields
 
-  Message parent;
+  Message parent
 
   /** Message fields. */
   private final List<Field> fields = new ArrayList<>()
@@ -21,6 +21,16 @@ final class Message extends Type {
   List<Field> getActiveFields() {
     List<Field> active = (List<Field>) fields.findAll() { Field f -> !f.skip }
     return Collections.unmodifiableList(active)
+  }
+
+  List<Field> getActiveFieldsWithParents() {
+    Message m = this
+    ArrayList<Field> result = new ArrayList<>()
+    while (m) {
+      result.addAll(m.activeFields)
+      m = m.parent
+    }
+    return result
   }
 
   Field fieldByName(final String name) {

--- a/helium/src/main/java/com/stanfy/helium/internal/utils/SelectionRules.java
+++ b/helium/src/main/java/com/stanfy/helium/internal/utils/SelectionRules.java
@@ -1,0 +1,101 @@
+package com.stanfy.helium.internal.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/** Include/exclude rules. */
+public class SelectionRules {
+
+  List<Pattern> includes = Collections.emptyList(), excludes = Collections.emptyList();
+
+  private final String name;
+
+  private final Map<String, SelectionRules> nested = new HashMap<>();
+
+  public SelectionRules(String name) {
+    this.name = name;
+  }
+
+  private static void checkNotNull(Object arg) {
+    if (arg == null) {
+      throw new IllegalArgumentException("Argument cannot be null");
+    }
+  }
+
+  public void nest(SelectionRules rules) {
+    nested.put(rules.name, rules);
+  }
+
+  public SelectionRules nested(String name) {
+    return nested.get(name);
+  }
+
+  public void includePatterns(List<Pattern> includes) {
+    checkNotNull(includes);
+    this.includes = includes;
+  }
+
+  public void excludePatterns(List<Pattern> excludes) {
+    checkNotNull(excludes);
+    this.excludes = excludes;
+  }
+
+  private static List<Pattern> convert(List<String> input) {
+    List<Pattern> result = new ArrayList<>(input.size());
+    for (String arg : input) {
+      result.add(Pattern.compile(arg));
+    }
+    return result;
+  }
+
+  public void includes(List<String> includes) {
+    checkNotNull(includes);
+    includePatterns(convert(includes));
+  }
+
+  public void excludes(List<String> excludes) {
+    checkNotNull(excludes);
+    excludePatterns(convert(excludes));
+  }
+
+  public void includes(String... includes) {
+    includes(Arrays.asList(includes));
+  }
+
+  public void excludes(String... excludes) {
+    excludes(Arrays.asList(excludes));
+  }
+
+  public boolean check(String input) {
+    boolean included = false;
+
+    if (includes.isEmpty()) {
+      included = true;
+    } else {
+      for (Pattern p : includes) {
+        if (p.matcher(input).matches()) {
+          included = true;
+          break;
+        }
+      }
+    }
+
+    if (excludes.isEmpty()) {
+      return included;
+    }
+    if (included) {
+      for (Pattern p : excludes) {
+        if (p.matcher(input).matches()) {
+          return false;
+        }
+      }
+    }
+    return included;
+  }
+  
+}

--- a/helium/src/test/groovy/com/stanfy/helium/internal/utils/SelectionRulesSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/internal/utils/SelectionRulesSpec.groovy
@@ -1,0 +1,117 @@
+package com.stanfy.helium.internal.utils
+
+import spock.lang.Specification
+
+import java.util.regex.Pattern
+
+/** Spec for selection rules. */
+class SelectionRulesSpec extends Specification {
+
+  def "empty rules"() {
+    given:
+    def rules = new SelectionRules("test")
+
+    expect:
+    rules.check("any")
+  }
+
+  def "include rules"() {
+    given:
+    def rules = new SelectionRules("test")
+    rules.includes 'test 1', 'test 2'
+
+    expect:
+    !rules.check("any")
+    rules.check("test 1")
+    rules.check("test 2")
+  }
+
+  def "exclude rules"() {
+    given:
+    def rules = new SelectionRules("test")
+    rules.excludes 'test 1', 'test 2'
+
+    expect:
+    rules.check("any")
+    !rules.check("test 1")
+    !rules.check("test 2")
+  }
+
+  def "exclude patterns"() {
+    given:
+    def rules = new SelectionRules("test")
+    rules.excludes '\\w+ 1'
+
+    expect:
+    rules.check("any")
+    !rules.check("test 1")
+    rules.check("test 2")
+    rules.check("test")
+  }
+
+  def "nesting"() {
+    given:
+    def root = new SelectionRules("root")
+    root.nest(new SelectionRules("foo"))
+    root.nest(new SelectionRules("bar"))
+
+    expect:
+    root.nested("foo").check("any")
+    root.nested("bar").check("any")
+  }
+
+  def "use strings for patterns"() {
+    given:
+    def rules = new SelectionRules("test")
+
+    when:
+    rules.includes '.*/some/path/.+', '/'
+
+    then:
+    rules.includes.size() == 2
+  }
+
+  def "use string list for patterns"() {
+    given:
+    def rules = new SelectionRules("test")
+
+    when:
+    rules.includes(['.*/some/path/.+', '/'])
+
+    then:
+    rules.includes.size() == 2
+  }
+
+  def "use string list for exclude patterns"() {
+    given:
+    def rules = new SelectionRules("test")
+
+    when:
+    rules.excludes(['.*/some/path/.+', '/'])
+
+    then:
+    rules.excludes.size() == 2
+  }
+
+  def "use patterns"() {
+    given:
+    def rules = new SelectionRules("test")
+
+    when:
+    rules.includePatterns([Pattern.compile('.*/some/path/.+')])
+
+    then:
+    rules.includes.size() == 1
+  }
+
+  def "use patterns for excludes"() {
+    given:
+    def rules = new SelectionRules("test")
+
+    when:
+    rules.excludePatterns([Pattern.compile('.*/some/path/.+')])
+
+    then:
+    rules.excludes.size() == 1
+  }
+}

--- a/helium/src/test/groovy/com/stanfy/helium/model/MessageSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/model/MessageSpec.groovy
@@ -7,8 +7,8 @@ import spock.lang.Specification
  */
 class MessageSpec extends Specification {
 
-  def Message message
-  def Type type
+  Message message
+  Type type
 
   def setup() {
     message = new Message(name: 'Test')
@@ -37,4 +37,18 @@ class MessageSpec extends Specification {
     message.activeFields.collect { it.name } == ['a', 'd']
   }
 
+  def "active fields with parent"() {
+    given:
+    Message granny = new Message(name: 'Granny')
+    Message parent = new Message(name: 'Parent', parent: granny)
+    message.parent = parent
+    message.addField(new Field(name: 'a', type: type))
+    parent.addField(new Field(name: 'b', type: type))
+    parent.addField(new Field(name: 'parent_skip', type: type, skip: true))
+    granny.addField(new Field(name: 'c', type: type))
+    granny.addField(new Field(name: 'granny_skip', type: type, skip: true))
+
+    expect:
+    message.activeFieldsWithParents.collect { it.name } == ['a', 'b', 'c']
+  }
 }

--- a/samples/swagger/build.gradle
+++ b/samples/swagger/build.gradle
@@ -23,7 +23,14 @@ task clean(type: Delete) {
 
 afterEvaluate {
   generateSwaggerSpec {
-    includes 'GET /products'
+    endpoints {
+      includes 'GET /products'
+    }
+    types {
+      'Product' {
+        excludes 'capacity'
+      }
+    }
   }
 
   task check(dependsOn: 'generateSwaggerSpec')
@@ -33,6 +40,10 @@ afterEvaluate {
     def json = new JsonSlurper().parse(file)
     assert json.info.title == 'Uber API'
     assert json.paths.'/products'.keySet() == ['get'] as Set
+    assert !json.definitions.'Product'.'properties'.containsKey('capacity')
+    assert json.definitions.'Product'.'properties'.containsKey('image')
+    assert !json.definitions.'Product'.'required'.contains('capacity')
+    assert json.definitions.'Product'.'required'.contains('image')
   }
 
 }


### PR DESCRIPTION
This allows to configure what fields should not be exposed in Swagger spec.