### PR TITLE
[ANDR-2234] Treat raw body as a file upload in Swagger

### DIFF
--- a/codegen/swagger/src/main/java/com/stanfy/helium/swagger/SwaggerHandler.java
+++ b/codegen/swagger/src/main/java/com/stanfy/helium/swagger/SwaggerHandler.java
@@ -9,6 +9,7 @@ import com.stanfy.helium.handler.codegen.json.schema.JsonSchemaGenerator;
 import com.stanfy.helium.handler.codegen.json.schema.JsonType;
 import com.stanfy.helium.handler.codegen.json.schema.SchemaBuilder;
 import com.stanfy.helium.internal.utils.Names;
+import com.stanfy.helium.model.DataType;
 import com.stanfy.helium.model.Dictionary;
 import com.stanfy.helium.model.Field;
 import com.stanfy.helium.model.Message;
@@ -209,6 +210,14 @@ public class SwaggerHandler implements Handler {
         p.type = schemaBuilder.translateType(part.getValue());
         method.parameters.add(p);
       }
+    } else if (m.getBody() instanceof DataType) {
+      method.consumes = Collections.singletonList("multipart/form-data");
+      Parameter p = new Parameter();
+      p.name = "file";
+      p.in = "formData";
+      p.required = true;
+      p.type = JsonType.FILE;
+      method.parameters.add(p);
     } else if (m.getType().isHasBody() && m.getBody() != null) {
       Parameter p = new Parameter();
       p.name = "body";


### PR DESCRIPTION
```
body data()
```

causes

```
Caused by: java.lang.NullPointerException
        at com.stanfy.helium.swagger.SwaggerHandler.resolveDefinition(SwaggerHandler.java:163)
        at com.stanfy.helium.swagger.SwaggerHandler.body(SwaggerHandler.java:217)
        at com.stanfy.helium.swagger.SwaggerHandler.buildSwagger(SwaggerHandler.java:126)
        at com.stanfy.helium.swagger.SwaggerHandler.handle(SwaggerHandler.java:74)
        at com.stanfy.helium.Helium.processBy(Helium.java:74)
        at com.stanfy.helium.Helium$processBy$2.call(Unknown Source)
        at com.stanfy.helium.gradle.tasks.SwaggerTask.doIt(SwaggerTask.groovy:25)
        at com.stanfy.helium.gradle.tasks.BaseHeliumTask.runWithClassLoader(BaseHeliumTask.groovy:58)
```